### PR TITLE
Disable board during win/draw

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -32,12 +32,14 @@ function playGame() {
       renderBoard();
       toggleWiggleAnimation(player);
       winnerAnimation();
+      disableBoard();
       player.saveWinsToStorage(game);
       setTimeout(function() {
         clearBoard()
       }, 2500);
     } else {
       renderBoard();
+
     };
   };
 };
@@ -123,4 +125,13 @@ function clearBoard() {
   changeGameHeader(player)
   renderBoard();
   toggleWiggleAnimation(player);
+  enableBoard();
 };
+
+function disableBoard() {
+  gameBoard.classList.add('disable-board')
+}
+
+function enableBoard() {
+  gameBoard.classList.remove('disable-board')
+}

--- a/styles.css
+++ b/styles.css
@@ -65,6 +65,10 @@ body {
   align-items: center;
 }
 
+.squares:hover {
+  cursor: pointer;
+}
+
 .squares>img {
   width: 2em;
 }
@@ -90,6 +94,10 @@ body {
 
 .draw {
   animation: draw 2.5s ease-in-out;
+}
+
+.disable-board {
+  pointer-events: none;
 }
 
 /* @-webkit-keyframes wiggle {


### PR DESCRIPTION
# Description of Changes

- Game board is disabled during win/draw timeout
- Cursor on game board is pointer when active, reverts to default when disabled
- closes #9 

# Issues

- N/A
